### PR TITLE
Update date logic to use current date as reference point

### DIFF
--- a/bordereaux_data_generator/configs/default_config.json
+++ b/bordereaux_data_generator/configs/default_config.json
@@ -48,6 +48,11 @@
         "output_name": "claim_status",
         "type": "string"
       },
+      "claim_close_date": {
+        "output_name": "claim_close_date",
+        "type": "date",
+        "format": "%Y-%m-%d"
+      },
       "loss_type": {
         "output_name": "loss_type",
         "type": "string"

--- a/bordereaux_data_generator/configs/tpa1_config.json
+++ b/bordereaux_data_generator/configs/tpa1_config.json
@@ -48,6 +48,11 @@
         "output_name": "status",
         "type": "string"
       },
+      "claim_close_date": {
+        "output_name": "close_date",
+        "type": "date",
+        "format": "%m/%d/%Y"
+      },
       "loss_type": {
         "output_name": "loss_category",
         "type": "string"

--- a/bordereaux_data_generator/configs/tpa2_config.json
+++ b/bordereaux_data_generator/configs/tpa2_config.json
@@ -21,6 +21,11 @@
         "output_name": "ClaimStatus",
         "type": "string"
       },
+      "claim_close_date": {
+        "output_name": "CloseDate",
+        "type": "date",
+        "format": "%Y-%m-%d"
+      },
       "date_of_loss": {
         "output_name": "LossDate",
         "type": "date",

--- a/bordereaux_data_generator/configs/tpa3_config.json
+++ b/bordereaux_data_generator/configs/tpa3_config.json
@@ -40,6 +40,11 @@
         "output_name": "current_status",
         "type": "string"
       },
+      "claim_close_date": {
+        "output_name": "date_closed",
+        "type": "date",
+        "format": "%d/%m/%Y"
+      },
       "total_incurred": {
         "output_name": "TOTAL_CLAIM_COST",
         "type": "decimal",


### PR DESCRIPTION
- Replace hardcoded 2025-12-31 with datetime.now() for dynamic reference date
- Implement enhanced reporting delay distribution (87%/8%/4%/1% for quick/normal/significant/very late reporting)
- Policy start dates now capped at today (no future policies)
- Added claim_close_date metric for future reporting and analysis implementation

Note: Some claim close dates may extend into future - design decision pending discussion